### PR TITLE
Fix for U4-1891

### DIFF
--- a/src/Umbraco.Web/HtmlHelperRenderExtensions.cs
+++ b/src/Umbraco.Web/HtmlHelperRenderExtensions.cs
@@ -280,7 +280,7 @@ namespace Umbraco.Web
 											   object additionalRouteVals,
 											   object htmlAttributes)
 		{
-			return html.BeginUmbracoForm(action, controllerName, additionalRouteVals, htmlAttributes.ToDictionary<object>());
+			return html.BeginUmbracoForm(action, controllerName, additionalRouteVals, HtmlHelper.AnonymousObjectToHtmlAttributes( htmlAttributes ));
 		}
 
 		/// <summary>


### PR DESCRIPTION
Use of HtmlHelper.AnonymousObjectToHtmlAttributes not a simple .ToDictionary() so that properties of the anonymous object follow the MVC convention of converting underscores to hypens
